### PR TITLE
Feature/sc 78821/ dev support add google pay payments demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.1.5",
-    "@publicsquare/elements-react": "1.9.0",
+    "@publicsquare/elements-react": "1.9.2",
     "@tailwindcss/forms": "^0.5.9",
     "classnames": "^2.5.1",
     "formik": "^2.4.6",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.1.5",
-    "@publicsquare/elements-react": "1.8.0",
+    "@publicsquare/elements-react": "1.9.0",
     "@tailwindcss/forms": "^0.5.9",
     "classnames": "^2.5.1",
     "formik": "^2.4.6",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,10 +10,11 @@ export enum PaymentMethodEnum {
   BANK_ACCOUNT = 'bank-account',
   BANK_ACCOUNT_VERIFICATION = 'bank-account-verification',
   APPLE_PAY = 'apple-pay',
+  GOOGLE_PAY = 'google-pay',
 }
 
 export const availablePaymentMethods = [
-  { id: PaymentMethodEnum.CREDIT_CARD, title: 'Credit card' },
+  { id: PaymentMethodEnum.CREDIT_CARD, title: 'Credit Card' },
   { id: PaymentMethodEnum.BANK_ACCOUNT, title: 'Bank Account (ACH)' },
   { id: PaymentMethodEnum.BANK_ACCOUNT_VERIFICATION, title: 'Bank Account Verification' },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,20 +469,20 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@publicsquare/elements-js@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@publicsquare/elements-js/-/elements-js-1.9.0.tgz#bc9142e22139f633a76f184724544b80681e1b35"
-  integrity sha512-DwrsfviHlSJBFlqIA4S3oxFmDMjagVKiS283Vb1FZr7EqJFnyucefSJweCJNCmJrKmBAMZXCWfL5vYo0a1+EJg==
+"@publicsquare/elements-js@1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@publicsquare/elements-js/-/elements-js-1.9.2.tgz#d7612e5b2113b6421c489beeb177241930ca343a"
+  integrity sha512-bj+UF0YebC6+Aga8y/ex7kPCYhZGS4zbm7YnIV+caNPHJRuahtkQBIzjzOveb+fanOb2QDM3/i1VWkS2vAwMfg==
   dependencies:
     "@basis-theory/basis-theory-js" "^4.22.1"
     prettier "^3.6.2"
 
-"@publicsquare/elements-react@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@publicsquare/elements-react/-/elements-react-1.9.0.tgz#cbb62929135d7cdba512556661ee59aca33fdbb1"
-  integrity sha512-PvlGOCbX1LNQvcRbDnA+TMxfLdlGX69uJoygxiZxoFjQ7nzBWt96FgnlJbdR5RkdCj/2KOYEsBU+jhaoDQcV2A==
+"@publicsquare/elements-react@1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@publicsquare/elements-react/-/elements-react-1.9.2.tgz#51c3799cbfb88fabb4977c4f781ea4ae3bd348af"
+  integrity sha512-j1KAUVH+Ebq3PeqxaO0GsX0nzsvCebPMNChPzDwXLkxJ0rpPfM3obZ5KPLJkOH7Wv5IQisbyHqrri7F6ICNM+Q==
   dependencies:
-    "@publicsquare/elements-js" "1.9.0"
+    "@publicsquare/elements-js" "1.9.2"
     prettier "^3.6.2"
 
 "@react-aria/focus@^3.20.2":

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,19 +469,21 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@publicsquare/elements-js@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@publicsquare/elements-js/-/elements-js-1.8.0.tgz#654ca5cffb14b336a8c9b8e1ff5ea80b33c15113"
-  integrity sha512-qWJXkboAtV9QQwsfGUMFf1qDjcYW3Cev459vtk7gOqFs4Jm5/IVfMiYnk7HhY7seMEzZ39yrdvrCzY9FFMScFA==
+"@publicsquare/elements-js@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@publicsquare/elements-js/-/elements-js-1.9.0.tgz#bc9142e22139f633a76f184724544b80681e1b35"
+  integrity sha512-DwrsfviHlSJBFlqIA4S3oxFmDMjagVKiS283Vb1FZr7EqJFnyucefSJweCJNCmJrKmBAMZXCWfL5vYo0a1+EJg==
   dependencies:
     "@basis-theory/basis-theory-js" "^4.22.1"
+    prettier "^3.6.2"
 
-"@publicsquare/elements-react@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@publicsquare/elements-react/-/elements-react-1.8.0.tgz#5f54de6a4baad68949abe0c6b511339fe7a0e4be"
-  integrity sha512-ma1m4dfIarzoIBJFtZEdq48Fby6mEyVVfKHG/imwkq0XwmnlqajoQ3Ik6pfmRyPmc7ct9Yzcr9/sf/l1rFvDNw==
+"@publicsquare/elements-react@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@publicsquare/elements-react/-/elements-react-1.9.0.tgz#cbb62929135d7cdba512556661ee59aca33fdbb1"
+  integrity sha512-PvlGOCbX1LNQvcRbDnA+TMxfLdlGX69uJoygxiZxoFjQ7nzBWt96FgnlJbdR5RkdCj/2KOYEsBU+jhaoDQcV2A==
   dependencies:
-    "@publicsquare/elements-js" "1.8.0"
+    "@publicsquare/elements-js" "1.9.0"
+    prettier "^3.6.2"
 
 "@react-aria/focus@^3.20.2":
   version "3.20.5"
@@ -2965,7 +2967,7 @@ prettier-plugin-tailwindcss@^0.6.8:
   resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.14.tgz#06701a580f7104c034ae3b699dbd17a80d67f0cd"
   integrity sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==
 
-prettier@^3.5.1:
+prettier@^3.5.1, prettier@^3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==


### PR DESCRIPTION
This pull request adds support for Google Pay as a payment method to the ecommerce checkout flow. The changes include updating dependencies, form validation, UI components, and the payment submission logic to handle Google Pay transactions alongside existing payment methods.

**Google Pay integration:**

* Added `GooglePayButtonElement` to the checkout page UI and implemented event handlers for Google Pay authorization and submission (`src/app/ecommerce/checkout/page.tsx`). [[1]](diffhunk://#diff-7fe50b809d550f107686db2c275d51350394d0eed60fef5379147281615a07a5R19) [[2]](diffhunk://#diff-7fe50b809d550f107686db2c275d51350394d0eed60fef5379147281615a07a5R524-R548)
* Updated form validation schema and initial values to include Google Pay, and added Google Pay to the list of supported payment methods (`src/app/ecommerce/checkout/page.tsx`). [[1]](diffhunk://#diff-7fe50b809d550f107686db2c275d51350394d0eed60fef5379147281615a07a5R94-R106) [[2]](diffhunk://#diff-7fe50b809d550f107686db2c275d51350394d0eed60fef5379147281615a07a5R131) [[3]](diffhunk://#diff-7fe50b809d550f107686db2c275d51350394d0eed60fef5379147281615a07a5R180-R181)
* Extended the payment submission hook to support Google Pay, including methods for creating Google Pay payment methods and handling payment authorization (`src/hooks/useCheckoutSubmit.ts`). [[1]](diffhunk://#diff-8c338aff94c6c3fe1c438f943d463140171d22a0967a7eb1053a9597a9fe1eadR76-R81) [[2]](diffhunk://#diff-8c338aff94c6c3fe1c438f943d463140171d22a0967a7eb1053a9597a9fe1eadR279-R351)
* Updated the payment method enum to include Google Pay (`src/utils.ts`).

**Dependency updates:**

* Upgraded `@publicsquare/elements-react` to version 1.9.2 to support Google Pay components (`package.json`).

** Shortcut Ticket **

- [SC-78821](https://app.shortcut.com/publicsq/story/78821/dev-support-add-google-pay-payments-demo)