### PR TITLE
BT Googlepay migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.1.5",
-    "@publicsquare/elements-react": "1.9.2",
+    "@publicsquare/elements-react": "1.9.4",
     "@tailwindcss/forms": "^0.5.9",
     "classnames": "^2.5.1",
     "formik": "^2.4.6",

--- a/src/hooks/useCheckoutSubmit.ts
+++ b/src/hooks/useCheckoutSubmit.ts
@@ -329,7 +329,7 @@ export function useCheckoutSubmit() {
     if (psq) {
       try {
         const response = await psq.googlePay.create({
-          google_payment_method_token: googlePaymentMethodToken,
+          google_payment_data: googlePaymentMethodToken,
         });
         if (response) {
           return response;

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,20 +469,20 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@publicsquare/elements-js@1.9.2":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@publicsquare/elements-js/-/elements-js-1.9.2.tgz#d7612e5b2113b6421c489beeb177241930ca343a"
-  integrity sha512-bj+UF0YebC6+Aga8y/ex7kPCYhZGS4zbm7YnIV+caNPHJRuahtkQBIzjzOveb+fanOb2QDM3/i1VWkS2vAwMfg==
+"@publicsquare/elements-js@1.9.4":
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/@publicsquare/elements-js/-/elements-js-1.9.4.tgz#4fbdb1b47be909ec8dbcb8f69011fe9583a3517e"
+  integrity sha512-qD6Z2eN5/usq7YBr72y2scHLWH16LcFGXrbAQxkMPwDTdQzowRIKQnrAyW8Q2QnJLUQkOmA/OfxrxYhDbrXpQQ==
   dependencies:
     "@basis-theory/basis-theory-js" "^4.22.1"
     prettier "^3.6.2"
 
-"@publicsquare/elements-react@1.9.2":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@publicsquare/elements-react/-/elements-react-1.9.2.tgz#51c3799cbfb88fabb4977c4f781ea4ae3bd348af"
-  integrity sha512-j1KAUVH+Ebq3PeqxaO0GsX0nzsvCebPMNChPzDwXLkxJ0rpPfM3obZ5KPLJkOH7Wv5IQisbyHqrri7F6ICNM+Q==
+"@publicsquare/elements-react@1.9.4":
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/@publicsquare/elements-react/-/elements-react-1.9.4.tgz#79f67093dd1088a1b6d1a0ed32a53a15bc965427"
+  integrity sha512-4rnI91UHSPevgs0MlOfTDK+HytfPRGDELn1kmDtdv+N+sH1hkedd0m8gPHOF1vqgARE5jflnDsICupnd06FAAQ==
   dependencies:
-    "@publicsquare/elements-js" "1.9.2"
+    "@publicsquare/elements-js" "1.9.4"
     prettier "^3.6.2"
 
 "@react-aria/focus@^3.20.2":


### PR DESCRIPTION
This pull request makes a minor dependency update and a small code change to improve naming consistency in the Google Pay integration.

- **Dependency update:**
  * Updated `@publicsquare/elements-react` from version `1.9.2` to `1.9.4` in `package.json` to keep dependencies current.

- **Google Pay integration:**
  * Renamed the parameter `google_payment_method_token` to `google_payment_data` when calling `psq.googlePay.create` in `useCheckoutSubmit.ts` for better clarity and consistency with expected API input.

**Shortcut Link**

- [SC-79263](https://app.shortcut.com/publicsq/story/79263/bt-googlepay-migration)